### PR TITLE
Support Rocq 9.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,8 @@ jobs:
               echo "::endgroup::"
 
               echo "::group::Install opam packages"
-              opam pin add -n -k version coq ${{ matrix.rocq }}
+              opam repo add rocq-released https://rocq-prover.org/opam/released
+              opam pin add -n -k version rocq-core ${{ matrix.rocq }}
               opam install --confirm-level=unsafe-yes --deps-only .
               echo "::endgroup::"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rocq: [ "9.0.0", "9.1.0" ]
+        rocq: [ "9.0.0", "9.1.1", "9.2.0" ]
         node: [ "24.13.0" ]
       fail-fast: false
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rocq: [ "9.0.0", "9.1.1", "9.2.0" ]
+        rocq: [ "9.0.1", "9.1.1", "9.2.0" ]
         node: [ "24.13.0" ]
       fail-fast: false
     steps:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The mechanization has the following properties:
 1.
     All of the core dependencies can be installed through [opam](https://opam.ocaml.org/):
     ```shell
+    opam repo add rocq-released https://rocq-prover.org/opam/released
     opam install . --deps-only
     ```
     This will allow you to step through the Rocq code, extract the OCaml code and compile it.

--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,8 @@
  (synopsis "A mechanization of the specification of ECMAScript regexes")
  (depends
   (ocaml (= 4.14.2))
-  (rocq-prover (>= 9.0.0))))
+  (rocq-stdlib (>= 9.0.0))
+  (rocq-core (>= 9.0.0))))
 
 (package
  (name warblre-engines)

--- a/dune-project
+++ b/dune-project
@@ -1,10 +1,10 @@
-(lang dune 3.21)
+(lang dune 3.23)
 
 (name warblre)
 
 (generate_opam_files true)
 
-(using rocq 0.11)
+(using rocq 0.13)
 (using melange 0.1)
 (using directory-targets 0.1)
 

--- a/engines/js/dune
+++ b/engines/js/dune
@@ -9,7 +9,7 @@
 ; Extract with different directives
 (rocq.extraction
  (prelude Extraction)
- (extracted_modules Extracted)
+ (extracted_files Extracted.ml Extracted.mli)
  (theories Warblre Ltac2 Stdlib))
 
 ; Make a library out of it

--- a/engines/ocaml/dune
+++ b/engines/ocaml/dune
@@ -9,7 +9,7 @@
 ; Extract with different directives
 (rocq.extraction
  (prelude Extraction)
- (extracted_modules Extracted)
+ (extracted_files Extracted.ml Extracted.mli)
  (theories Warblre Ltac2 Stdlib))
 
 ; Make a library out of it

--- a/examples/dune-project
+++ b/examples/dune-project
@@ -1,9 +1,9 @@
-(lang dune 3.21)
+(lang dune 3.23)
 ; This package is defined in a sub dune-project to prevent the installation of example executables
 
 (generate_opam_files false)
 
-(using rocq 0.11)
+(using rocq 0.13)
 (using melange 0.1)
 (using directory-targets 0.1)
 

--- a/mechanization/dune
+++ b/mechanization/dune
@@ -4,4 +4,7 @@
  (name Warblre)
  (package warblre)
  (generate_project_file)
+ (flags
+   ; For compatibility with Rocq 9.1 and lower
+   -w -notation-for-abbreviation)
  (theories Ltac2 Stdlib))

--- a/mechanization/dune
+++ b/mechanization/dune
@@ -6,5 +6,7 @@
  (generate_project_file)
  (flags
    ; For compatibility with Rocq 9.1 and lower
-   -w -notation-for-abbreviation)
+   -w -notation-for-abbreviation
+   ; These are difficult to resolve for focus tactics
+   -w -level-tolerance)
  (theories Ltac2 Stdlib))

--- a/mechanization/spec/Inst.v
+++ b/mechanization/spec/Inst.v
@@ -543,9 +543,9 @@ Definition character_of_Ascii (a: Stdlib.Strings.Ascii.ascii) :=
 Example flags :=
   (RegExpFlags.make false false false false false tt false).
 
-Notation "! r" := (get_success (initialize r flags)) (at level 0).
-Notation "$ c" := (character_of_Ascii c) (at level 0).
-Notation "$$ s" := (string_of_String s) (at level 0).
+Notation "! r" := (get_success (initialize r flags)) (at level 9).
+Notation "$ c" := (character_of_Ascii c) (at level 9).
+Notation "$$ s" := (string_of_String s) (at level 9).
 
 (* Hide the matching functions in the outputs below*)
 Arguments Exotic {C S UP}%_type_scope {H H0 H1} _ {_}.

--- a/mechanization/spec/base/Base.v
+++ b/mechanization/spec/base/Base.v
@@ -48,9 +48,9 @@ Instance int_indexer: Indexer Z := {
   update_using := fun T F f ls i v => Result.assertion_failed; (* This operation is never used. *)
 }.
 
-Notation "ls '[' i ']'" := (indexing ls i) (at level 98, left associativity).
-Notation "'set' ls '[' i ']' ':=' v 'in' z" := (let! ls: list _ =<< update ls i v in z) (at level 200, ls at level 97, i at level 90, right associativity).
-Notation "'set' ls '[' s '---' e ']' ':=' v 'in' z" := (let! ls: list _ =<< List.Update.Nat.Batch.update v ls (List.Range.Nat.Bounds.range (s - 1) (e - 1)) in z) (at level 200, ls at level 97, s at level 90, e at level 90, right associativity).
+Notation "ls '[' i ']'" := (indexing ls i) (at level 1, left associativity).
+Notation "'set' ls '[' i ']' ':=' v 'in' z" := (let! ls: list _ =<< update ls i v in z) (at level 200, ls at level 0, i at level 90, right associativity).
+Notation "'set' ls '[' s '---' e ']' ':=' v 'in' z" := (let! ls: list _ =<< List.Update.Nat.Batch.update v ls (List.Range.Nat.Bounds.range (s - 1) (e - 1)) in z) (at level 200, ls at level 0, s at level 90, e at level 90, right associativity).
 
 (** The is (not) operator *)
 

--- a/mechanization/tactics/Focus.v
+++ b/mechanization/tactics/Focus.v
@@ -25,11 +25,12 @@ Inductive focus :=
 (** Grammar to write focuses. *)
 (* TODO: the levels were changed to avoid factorization issues, but
    I have not put enough thoughts into it to be sure these changes are fine. *)
+Set Warnings "-postfix-notation-not-level-1".
 Declare Custom Entry focus.
 Notation "'<!' e '!>'" := e (e custom focus at level 99).
 Notation "'[]'" := Here (in custom focus at level 0).
 Notation "'(' f ')'" := f (in custom focus at level 0, f at level 99).
-Notation "'if' f 'then' '_' 'else' '_'" := (IteCond f) (in custom focus at level 99).
+Notation "'if' f 'then' '_' 'else' '_'" := (IteCond f) (in custom focus at level 0).
 Notation "f '->' '_'" := (ArrowL f) (in custom focus at level 70, right associativity).
 Notation "'_' '->' f" := (ArrowR f) (in custom focus at level 70, right associativity).
 Notation "f '_'" := (AppL f) (in custom focus at level 70, no associativity).

--- a/warblre-engines.opam
+++ b/warblre-engines.opam
@@ -7,7 +7,7 @@ license: "BSD-3-Clause"
 homepage: "https://github.com/epfl-systemf/warblre"
 bug-reports: "https://github.com/epfl-systemf/warblre/issues"
 depends: [
-  "dune" {>= "3.21"}
+  "dune" {>= "3.23"}
   "warblre" {= version}
   "integers" {>= "0.7.0"}
   "uucp" {>= "15.0.0"}

--- a/warblre.opam
+++ b/warblre.opam
@@ -9,7 +9,8 @@ bug-reports: "https://github.com/epfl-systemf/warblre/issues"
 depends: [
   "dune" {>= "3.21"}
   "ocaml" {= "4.14.2"}
-  "rocq-prover" {>= "9.0.0"}
+  "rocq-stdlib" {>= "9.0.0"}
+  "rocq-core" {>= "9.0.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/warblre.opam
+++ b/warblre.opam
@@ -7,7 +7,7 @@ license: "BSD-3-Clause"
 homepage: "https://github.com/epfl-systemf/warblre"
 bug-reports: "https://github.com/epfl-systemf/warblre/issues"
 depends: [
-  "dune" {>= "3.21"}
+  "dune" {>= "3.23"}
   "ocaml" {= "4.14.2"}
   "rocq-stdlib" {>= "9.0.0"}
   "rocq-core" {>= "9.0.0"}


### PR DESCRIPTION
Eh, more `Notation` deprecations

- [x] ~`Focus.v` notations generate many warnings~ -> warning is ignored. Resolving this seems quite difficult. We will wait for if or when it is actually a problem. For now, everything parses correctly regardless.
- [x] melange does not build, but it does not even build on the main branch of Warblre