### PR TITLE
Move spec notations out of Base and change l[i] to l.[i]

### DIFF
--- a/mechanization/props/Match.v
+++ b/mechanization/props/Match.v
@@ -1,5 +1,5 @@
 From Stdlib Require Import PeanoNat ZArith Bool Lia Program.Equality List.
-From Warblre Require Import List Tactics Retrieve Specialize Focus Result Base Errors Patterns Node NodeProps StaticSemantics Notation Semantics Definitions EarlyErrors Compile RegExpRecord.
+From Warblre Require Import List Tactics Retrieve Specialize Focus Result Base Notations Errors Patterns Node NodeProps StaticSemantics Notation Semantics Definitions EarlyErrors Compile RegExpRecord.
 
 Import Result.Notations.
 Import Semantics.
@@ -58,7 +58,7 @@ Module Match.
                                       let e := fresh c "_end" in
                                       destruct c as [ s e ]
         | [ VCs : List.Forall.Forall ?c (Valid ?str),
-            Indexed : (?c [?n]) = Success (Some (capture_range ?s ?e))
+            Indexed : (?c.[?n]) = Success (Some (capture_range ?s ?e))
           |- _ ] => is_var c; lazymatch goal with
                     | [ _: (s <= e)%Z |- _ ] => fail
                     | [ |- _ ] => let H := fresh "VCR_" s "_" e in

--- a/mechanization/spec/Frontend.v
+++ b/mechanization/spec/Frontend.v
@@ -1,5 +1,5 @@
 From Stdlib Require Import List ZArith.
-From Warblre Require Import RegExpRecord Base Errors Notation Patterns Node StaticSemantics Semantics Result List Characters Return.
+From Warblre Require Import RegExpRecord Base Notations Errors Notation Patterns Node StaticSemantics Semantics Result List Characters Return.
 
 Import Result.Notations.
 Import Notation.

--- a/mechanization/spec/Semantics.v
+++ b/mechanization/spec/Semantics.v
@@ -1,5 +1,5 @@
 From Stdlib Require Import PeanoNat ZArith Bool Lia Program.Equality List Program.Wf.
-From Warblre Require Import RegExpRecord Tactics Focus Result Base Patterns Errors StaticSemantics Node Notation List Typeclasses.
+From Warblre Require Import RegExpRecord Tactics Focus Result Base Notations Patterns Errors StaticSemantics Node Notation List Typeclasses.
 
 Import Result.Notations.
 Import Result.Notations.Boolean.
@@ -148,7 +148,7 @@ Module Semantics. Section main.
       (*>> i. Let index be min(e, f). <<*)
       let index := Z.min e f in
       (*>> j. Let ch be the character Input[index]. <<*)
-      let! chr =<< input[ index ] in
+      let! chr =<< input.[index] in
       (*>> k. Let cc be Canonicalize(rer, ch). <<*)
       let cc := Character.canonicalize rer chr in
       (*>> l. If there exists a member a of A such that Canonicalize(rer, a) is cc, let found be true. Otherwise, let found be false. <<*)
@@ -183,8 +183,8 @@ Module Semantics. Section main.
       let input := MatchState.input x in
       (*>> d. Let cap be x's captures List. <<*)
       let cap := MatchState.captures x in
-      (*>> e. Let r be cap[ n ]. <<*)
-      let! r =<< cap[n] in
+      (*>> e. Let r be cap[n]. <<*)
+      let! r =<< cap.[n] in
       (*>> f. If r is undefined, return c(x). <<*)
       if r is undefined
         then c x else
@@ -212,9 +212,9 @@ Module Semantics. Section main.
       let g := Z.min e f in
       (*>> p. If there exists an integer i in the interval from 0 (inclusive) to len (exclusive) such that Canonicalize(rer, Input[rs + i]) is not Canonicalize(rer, Input[g + i]), return failure. <<*)
       let! b: bool =<< List.Exists.exist (List.Range.Int.Bounds.range 0 len) (fun (i: Z) =>
-        let! rsi =<< input[ (rs + i)%Z ] in
+        let! rsi =<< input.[(rs + i)%Z] in
         let rsi := Character.canonicalize rer rsi in
-        let! gi =<< input[ (g + i)%Z ] in
+        let! gi =<< input.[(g + i)%Z] in
         let gi := Character.canonicalize rer gi in
         (rsi != gi))
       in
@@ -451,8 +451,8 @@ Module Semantics. Section main.
     if (e =? -1)%Z || (e =? inputLength)%Z then
       false
     else
-    (*>> 3. Let c be the character Input[ e ]. <<*)
-    let! c =<< input[e] in
+    (*>> 3. Let c be the character Input[e]. <<*)
+    let! c =<< input.[e] in
     (*>> 4. If WordCharacters(rer) contains c, return true. <<*)
     let! wc =<< wordCharacters rer in
     if CharSet.contains wc c then
@@ -499,7 +499,7 @@ Module Semantics. Section main.
     let cap := MatchState.captures x in
     (*>> 4. For each integer k in the inclusive interval from parenIndex + 1 to parenIndex + parenCount, set cap[k] to undefined. <<*)
     (* + The additional +1 is normal: the range operator --- is non-inclusive on the right +*)
-    set cap[(parenIndex + 1) --- (parenIndex + parenCount + 1) ] := undefined in
+    set cap.[(parenIndex + 1) --- (parenIndex + parenCount + 1)] := undefined in
     (*>> 5. Let Input be x's input. <<*)
     let input := MatchState.input x in
     (*>> 6. Let e be x's endIndex. <<*)
@@ -647,7 +647,7 @@ Module Semantics. Section main.
           (*>> d. Let e be x's endIndex. <<*)
           let e := MatchState.endIndex x in
           (*>> e. If e = 0, or if rer.[[Multiline]] is true and the character Input[e - 1] is matched by LineTerminator, then <<*)
-          if! (e =? 0)%Z ||! ((RegExpRecord.multiline rer is true) &&! (let! d =<< input[(e-1)%Z] in CharSet.contains Characters.line_terminators d)) then
+          if! (e =? 0)%Z ||! ((RegExpRecord.multiline rer is true) &&! (let! d =<< input.[(e-1)%Z] in CharSet.contains Characters.line_terminators d)) then
             (*>> i. Return c(x). <<*)
             c x
           else
@@ -667,7 +667,7 @@ Module Semantics. Section main.
           (*>> e. Let InputLength be the number of elements in Input. <<*)
           let inputLength := List.length input in
           (*>> f. If e = InputLength, or if rer.[[Multiline]] is true and the character Input[e] is matched by LineTerminator, then <<*)
-          if! (e =? inputLength)%Z ||! ((RegExpRecord.multiline rer is true) &&! (let! d =<< input[e] in CharSet.contains Characters.line_terminators d)) then
+          if! (e =? inputLength)%Z ||! ((RegExpRecord.multiline rer is true) &&! (let! d =<< input.[e] in CharSet.contains Characters.line_terminators d)) then
             (*>> i. Return c(x). <<*)
             c x
           else
@@ -908,7 +908,7 @@ Module Semantics. Section main.
                 capture_range ye xe
             in
             (*>> viii. Set cap[parenIndex + 1] to r. <<*)
-            set cap[parenIndex + 1] := r in
+            set cap.[parenIndex + 1] := r in
             (*>> ix. Let z be the MatchState (Input, ye, cap). <<*)
             let z := match_state input ye cap in
             (*>> x. Return c(z). <<*)

--- a/mechanization/spec/StaticSemantics.v
+++ b/mechanization/spec/StaticSemantics.v
@@ -1,5 +1,5 @@
 From Stdlib Require Import PeanoNat List Bool.
-From Warblre Require Import Result List Base Errors Result Patterns Node NodeProps Typeclasses.
+From Warblre Require Import Result List Base Notations Errors Result Patterns Node NodeProps Typeclasses.
 
 Import Coercions.
 Import Result.Notations.
@@ -371,7 +371,7 @@ Section StaticSemantics.
     (* + Return the nth group INSIDE this node +*)
     Definition nth_group_in {F} `{Result.AssertionError F} (r: RegexNode) (n: non_neg_integer): Result.Result RegexNode F :=
       let groups := all_groups_in r in
-      groups[n].
+      groups.[n].
 
     Definition nth_group {F} `{Result.AssertionError F} (r: Regex) (n: non_neg_integer): Result.Result RegexNode F :=
       nth_group_in (r, nil) n.

--- a/mechanization/spec/base/Base.v
+++ b/mechanization/spec/base/Base.v
@@ -1,5 +1,5 @@
-From Stdlib Require Import ZArith Lia List ListSet Bool.
-From Warblre Require Import Tactics List Result.
+From Stdlib Require Import ZArith.
+From Warblre Require Import List Result.
 From Warblre Require Export Parameters.
 
 (** The base files.
@@ -13,11 +13,6 @@ From Warblre Require Export Parameters.
 
 (* Exports all of the other 'base' files *)
 From Warblre Require Export Typeclasses Characters Numeric Coercions.
-
-(** Notations for list operations *)
-
-Import Result.Notations.
-Local Open Scope result_flow.
 
 Class Indexer (I: Type) := {
   index_using: forall (T F: Type) (_: Result.AssertionError F) (ls: list T) (i: I), Result.Result T F;
@@ -47,15 +42,6 @@ Instance int_indexer: Indexer Z := {
   index_using := @List.Indexing.Int.indexing;
   update_using := fun T F f ls i v => Result.assertion_failed; (* This operation is never used. *)
 }.
-
-Notation "ls '[' i ']'" := (indexing ls i) (at level 1, left associativity).
-Notation "'set' ls '[' i ']' ':=' v 'in' z" := (let! ls: list _ =<< update ls i v in z) (at level 200, ls at level 0, i at level 90, right associativity).
-Notation "'set' ls '[' s '---' e ']' ':=' v 'in' z" := (let! ls: list _ =<< List.Update.Nat.Batch.update v ls (List.Range.Nat.Bounds.range (s - 1) (e - 1)) in z) (at level 200, ls at level 0, s at level 90, e at level 90, right associativity).
-
-(** The is (not) operator *)
-
-Notation "m 'is' p" := (match m with | p => true | _ => false end) (at level 100, p pattern, no associativity).
-Notation "m 'is' 'not' p" := (match m with | p => false | _ => true end) (at level 100, p pattern, no associativity).
 
 (** Additional datatypes which are never properly defined. *)
 Inductive Direction :=

--- a/mechanization/spec/base/Notations.v
+++ b/mechanization/spec/base/Notations.v
@@ -1,0 +1,15 @@
+From Warblre Require Import List Result Base.
+
+Import Result.Notations.
+Local Open Scope result_flow.
+
+(** Notations for list operations *)
+
+Notation "ls '.[' i ']'" := (indexing ls i) (at level 1, left associativity).
+Notation "'set' ls '.[' i ']' ':=' v 'in' z" := (let! ls: list _ =<< update ls i v in z) (at level 200, ls at level 0, i at level 90, right associativity).
+Notation "'set' ls '.[' s '---' e ']' ':=' v 'in' z" := (let! ls: list _ =<< List.Update.Nat.Batch.update v ls (List.Range.Nat.Bounds.range (s - 1) (e - 1)) in z) (at level 200, ls at level 0, s at level 90, e at level 90, right associativity).
+
+(** The is (not) operator *)
+
+Notation "m 'is' p" := (match m with | p => true | _ => false end) (at level 100, p pattern, no associativity).
+Notation "m 'is' 'not' p" := (match m with | p => false | _ => true end) (at level 100, p pattern, no associativity).


### PR DESCRIPTION
Follow up to 8a388bf, which broke Stdlib's list notations.